### PR TITLE
Issue 14: Clean up detail view

### DIFF
--- a/Simple Photo Viewer/MainContentView.swift
+++ b/Simple Photo Viewer/MainContentView.swift
@@ -22,8 +22,6 @@ struct MainContentView: View {
 
             if isDetailViewPresented.wrappedValue, let selectedAsset = selectedAsset.wrappedValue {
                 DetailView(viewModel: viewModel, asset: selectedAsset, isPresented: isDetailViewPresented)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.black.opacity(0.7).edgesIgnoringSafeArea(.all))
             }
         }
     }


### PR DESCRIPTION
- Do not always show close button
- Move detail view logic out of main view 
- Adjust padding of close button
- Take up whole screen
- Accept taps outside the content
- Make close button look more like standard controls (simple white/black), but keep it a little larger than usual for accessibility