### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ DerivedData
 .idea/
 *.hmap
 xcuserdata/*
+
+# Claude Code
+.claude/
+CLAUDE.md

--- a/Simple Photo Viewer.xcodeproj/project.pbxproj
+++ b/Simple Photo Viewer.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Simple Photo Viewer/Simple_Photo_Viewer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Simple Photo Viewer/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -346,7 +346,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -365,7 +365,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Simple Photo Viewer/Simple_Photo_Viewer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Simple Photo Viewer/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -389,7 +389,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Simple Photo Viewer/ContentView.swift
+++ b/Simple Photo Viewer/ContentView.swift
@@ -21,9 +21,9 @@ struct ContentView: View {
     
     var body: some View {
         Group {
-            if viewModel.hasPhotoLibraryAccess && !isShowingLoader {
+            if viewModel.hasPhotoLibraryAccess && viewModel.albumsLoaded && !isShowingLoader {
                 MainContentView(viewModel: viewModel, selectedAsset: $selectedAsset, isDetailViewPresented: $isDetailViewPresented)
-            } else if viewModel.photoLibraryAccessHasBeenChecked && !isShowingLoader {
+            } else if viewModel.photoLibraryAccessHasBeenChecked && !viewModel.hasPhotoLibraryAccess && !isShowingLoader {
                 AccessDeniedView()
                     .onAppear {
                         setupAccessCheckTimer()

--- a/Simple Photo Viewer/DetailView.swift
+++ b/Simple Photo Viewer/DetailView.swift
@@ -17,8 +17,8 @@ struct DetailView: View {
     @State private var currentIndex: Int = 0
     @State private var image: UIImage? = nil
     @State private var player: AVPlayer? = nil
-    @State private var playerItemStatusObserver: Any?
-    @State private var playerEndObserver: Any?
+    @State private var playerItemStatusObserver: NSKeyValueObservation?
+    @State private var playerEndObserver: NSObjectProtocol?
     @State private var isAssetLoading: Bool = false
     @State private var isTransitioning: Bool = false
 
@@ -233,7 +233,7 @@ struct DetailView: View {
 
     private func cleanupPlayerObservers() {
         if let observer = playerItemStatusObserver {
-            // Note: KVO observer invalidation happens automatically when observer is deallocated
+            observer.invalidate()
             playerItemStatusObserver = nil
         }
 

--- a/Simple Photo Viewer/DetailView.swift
+++ b/Simple Photo Viewer/DetailView.swift
@@ -18,7 +18,9 @@ struct DetailView: View {
     @State private var image: UIImage? = nil
     @State private var player: AVPlayer? = nil
     @State private var playerItemStatusObserver: Any?
+    @State private var playerEndObserver: Any?
     @State private var isAssetLoading: Bool = false
+    @State private var isTransitioning: Bool = false
 
     @State private var isZoomed: Bool = false
     @State private var offset = CGSize.zero
@@ -202,6 +204,9 @@ struct DetailView: View {
     }
 
     private func setupPlayer(with playerItem: AVPlayerItem) {
+        // Clean up any existing observers first
+        cleanupPlayerObservers()
+
         playerItemStatusObserver = playerItem.observe(\.status, options: [.new, .old]) { item, _ in
             if item.status == .readyToPlay {
                 DispatchQueue.main.async {
@@ -211,7 +216,7 @@ struct DetailView: View {
             }
         }
 
-        NotificationCenter.default.addObserver(
+        playerEndObserver = NotificationCenter.default.addObserver(
             forName: .AVPlayerItemDidPlayToEndTime,
             object: playerItem,
             queue: .main
@@ -222,11 +227,23 @@ struct DetailView: View {
         self.player = AVPlayer(playerItem: playerItem)
     }
 
+    private func cleanupPlayerObservers() {
+        if let observer = playerItemStatusObserver {
+            // Note: KVO observer invalidation happens automatically when observer is deallocated
+            playerItemStatusObserver = nil
+        }
+
+        if let observer = playerEndObserver {
+            NotificationCenter.default.removeObserver(observer)
+            playerEndObserver = nil
+        }
+    }
+
     private func stopAndReleasePlayer() {
         DispatchQueue.main.async {
             self.player?.pause()
             self.player = nil
-            self.playerItemStatusObserver = nil
+            self.cleanupPlayerObservers()
         }
     }
 
@@ -316,28 +333,38 @@ struct DetailView: View {
     private var swipeGesture: some Gesture {
         DragGesture()
             .onEnded { gesture in
-                guard !self.isAssetLoading && self.scale == 1.0 else { return }
+                guard !self.isAssetLoading && !self.isTransitioning && self.scale == 1.0 else { return }
                 if gesture.translation.width > 100 {
                     // logic for swiping right
                     if self.currentIndex > 0 {
+                        self.isTransitioning = true
                         self.stopAndReleasePlayer()
                         self.viewModel.cancelVideoLoading()
                         self.swipeDirection = .right
                         withAnimation {
                             self.currentIndex -= 1
                         }
-                        self.loadAsset()
+                        // Delay loadAsset to ensure cleanup completes
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            self.loadAsset()
+                            self.isTransitioning = false
+                        }
                     }
                 } else if gesture.translation.width < -100 {
                     // logic for swiping left
                     if self.currentIndex < self.viewModel.images.count - 1 {
+                        self.isTransitioning = true
                         self.stopAndReleasePlayer()
                         self.viewModel.cancelVideoLoading()
                         self.swipeDirection = .left
                         withAnimation {
                             self.currentIndex += 1
                         }
-                        self.loadAsset()
+                        // Delay loadAsset to ensure cleanup completes
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            self.loadAsset()
+                            self.isTransitioning = false
+                        }
                     }
                 }
             }

--- a/Simple Photo Viewer/DetailView.swift
+++ b/Simple Photo Viewer/DetailView.swift
@@ -30,6 +30,10 @@ struct DetailView: View {
 
     @State private var swipeDirection: SwipeDirection = .right // need to set an initial direction for the first asset loaded to work
 
+    // Delay between cleanup and loading next asset to prevent race conditions
+    // Ensures video player observers are fully removed before new asset loads
+    private let transitionDelay: TimeInterval = 0.1
+
     enum SwipeDirection {
         case left, right, none
     }
@@ -345,7 +349,7 @@ struct DetailView: View {
                             self.currentIndex -= 1
                         }
                         // Delay loadAsset to ensure cleanup completes
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + transitionDelay) {
                             self.loadAsset()
                             self.isTransitioning = false
                         }
@@ -361,7 +365,7 @@ struct DetailView: View {
                             self.currentIndex += 1
                         }
                         // Delay loadAsset to ensure cleanup completes
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + transitionDelay) {
                             self.loadAsset()
                             self.isTransitioning = false
                         }

--- a/Simple Photo Viewer/ViewModel.swift
+++ b/Simple Photo Viewer/ViewModel.swift
@@ -266,6 +266,7 @@ class ViewModel: ObservableObject {
 
         if let requestID = videoRequestID {
             PHImageManager.default().cancelImageRequest(requestID)
+            videoRequestID = nil
         }
 
         videoRequestID = PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { (avAsset, audioMix, info) in

--- a/Simple Photo Viewer/ViewModel.swift
+++ b/Simple Photo Viewer/ViewModel.swift
@@ -15,6 +15,7 @@ class ViewModel: ObservableObject {
     @Published var selectedAlbumIdentifier: String?
     @Published var hasPhotoLibraryAccess: Bool = false
     @Published var photoLibraryAccessHasBeenChecked: Bool = false
+    @Published var albumsLoaded: Bool = false
     @Published var showAlbumViewSettings: Bool = true
     @Published var prefetchedImage: UIImage?
     @Published var livePhoto: PHLivePhoto?
@@ -22,7 +23,6 @@ class ViewModel: ObservableObject {
     private var fetchOffset = 0
     private let fetchLimit = 250
     private var currentAlbum: PHAssetCollection?
-    private var allPhotos: PHFetchResult<PHAsset>
     private var loadedAlbumSettingsData: Data?
     private let decoder = JSONDecoder()
     var videoRequestID: PHImageRequestID?
@@ -33,10 +33,6 @@ class ViewModel: ObservableObject {
         } else {
             showAlbumViewSettings = true
         }
-        let fetchOptions = PHFetchOptions()
-        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-        fetchOptions.predicate = NSPredicate(format: "mediaType == %d OR mediaType == %d", PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
-        allPhotos = PHAsset.fetchAssets(with: fetchOptions)
         loadAlbumSettings()
         checkPhotoLibraryAccess()
         setupAppActiveObserver()
@@ -104,7 +100,14 @@ class ViewModel: ObservableObject {
 
     func checkPhotoLibraryAccess() {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        updateAccessStatus(status)
+
+        if status == .notDetermined {
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                self.updateAccessStatus(newStatus)
+            }
+        } else {
+            updateAccessStatus(status)
+        }
     }
 
     private func updateAccessStatus(_ status: PHAuthorizationStatus) {
@@ -143,45 +146,40 @@ class ViewModel: ObservableObject {
     }
 
     func fetchAlbums() {
-        let fetchOptions = PHFetchOptions()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let fetchOptions = PHFetchOptions()
 
-        let allAlbumsFetchResult = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
-        let allSmartAlbumsFetchResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: fetchOptions)
+            let allAlbumsFetchResult = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
+            let allSmartAlbumsFetchResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: fetchOptions)
 
-        let allAlbums = (allAlbumsFetchResult.objects(at: IndexSet(0..<allAlbumsFetchResult.count)) +
-                         allSmartAlbumsFetchResult.objects(at: IndexSet(0..<allSmartAlbumsFetchResult.count)))
-            .filter(albumContainsImagesAndVideos)
+            let allAlbums = (allAlbumsFetchResult.objects(at: IndexSet(0..<allAlbumsFetchResult.count)) +
+                             allSmartAlbumsFetchResult.objects(at: IndexSet(0..<allSmartAlbumsFetchResult.count)))
+                .filter(self.albumContainsImagesAndVideos)
 
-        func latestAssetDate(in album: PHAssetCollection) -> Date? {
-            let assetsFetchOptions = PHFetchOptions()
-            assetsFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-            assetsFetchOptions.fetchLimit = 1
-            let assets = PHAsset.fetchAssets(in: album, options: assetsFetchOptions)
-            return assets.firstObject?.creationDate
-        }
-
-        let sortedAlbums = allAlbums.sorted {
-            latestAssetDate(in: $0) ?? Date.distantPast > latestAssetDate(in: $1) ?? Date.distantPast
-        }
-
-        DispatchQueue.main.async {
-            self.albums = sortedAlbums
-
-            sortedAlbums.forEach { album in
-                if self.albumSettings[album.localIdentifier] == nil {
-                    if let data = UserDefaults.standard.data(forKey: "albumSettings") {
-                        let jsonDecoder = JSONDecoder()
-                        if let decodedSettings = try? jsonDecoder.decode(AlbumSettings.self, from: data) {
-                            self.albumSettings[album.localIdentifier] = decodedSettings
-                        }
-                    } else {
-                        let dummyDecoder: Decoder? = nil
-                        self.albumSettings[album.localIdentifier] = AlbumSettings(from: dummyDecoder)
-                    }
-                }
+            func latestAssetDate(in album: PHAssetCollection) -> Date? {
+                let assetsFetchOptions = PHFetchOptions()
+                assetsFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+                assetsFetchOptions.fetchLimit = 1
+                let assets = PHAsset.fetchAssets(in: album, options: assetsFetchOptions)
+                return assets.firstObject?.creationDate
             }
 
-            self.selectFirstVisibleAlbum()
+            let sortedAlbums = allAlbums.sorted {
+                latestAssetDate(in: $0) ?? Date.distantPast > latestAssetDate(in: $1) ?? Date.distantPast
+            }
+
+            DispatchQueue.main.async {
+                self.albums = sortedAlbums
+
+                sortedAlbums.forEach { album in
+                    if self.albumSettings[album.localIdentifier] == nil {
+                        self.albumSettings[album.localIdentifier] = AlbumSettings(from: nil)
+                    }
+                }
+
+                self.selectFirstVisibleAlbum()
+                self.albumsLoaded = true
+            }
         }
     }
 
@@ -270,14 +268,16 @@ class ViewModel: ObservableObject {
             PHImageManager.default().cancelImageRequest(requestID)
         }
 
-        PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { (avAsset, audioMix, info) in
+        videoRequestID = PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { (avAsset, audioMix, info) in
             DispatchQueue.main.async {
                 guard let avAsset = avAsset as? AVURLAsset else {
+                    self.videoRequestID = nil
                     completion(nil)
                     return
                 }
 
                 let playerItem = AVPlayerItem(url: avAsset.url)
+                self.videoRequestID = nil
                 completion(playerItem)
             }
         }
@@ -360,6 +360,7 @@ class ViewModel: ObservableObject {
                 } else {
                     self.selectFirstVisibleAlbum()
                 }
+                self.albumsLoaded = true
             }
         }
     }


### PR DESCRIPTION
This pull request improves the reliability and user experience of the photo viewer app by refining album loading state management, tightening access control logic, and enhancing the video player lifecycle and swipe gesture handling. The changes ensure that content is only displayed after albums are fully loaded, prevent race conditions during asset transitions, and clean up observers properly to avoid resource leaks.

**State Management and Access Control:**
- Added a new `albumsLoaded` property to `ViewModel` and updated the logic in `ContentView` to ensure that the main content is only shown when both photo library access is granted and albums have finished loading. The access denied view is now only shown if access has been checked and denied. [[1]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737R18-L25) [[2]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737L172-R182) [[3]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737R363) [[4]](diffhunk://#diff-bc6716335b70383eddd4691af9a29d440d351854ed92505d5cf2fe4cea5bf61cL24-R26)

**Video Player Lifecycle and Observer Cleanup:**
- Improved the video player lifecycle in `DetailView` by introducing a `cleanupPlayerObservers` method, tracking both KVO and notification observers, and ensuring they are properly removed when the player is stopped or replaced. This prevents potential memory leaks and duplicate observer issues. [[1]](diffhunk://#diff-7cadcbfeb0e644a7a53c88412b316dbc0f222422c49f3e6723e1237c8f7a41adR21-R23) [[2]](diffhunk://#diff-7cadcbfeb0e644a7a53c88412b316dbc0f222422c49f3e6723e1237c8f7a41adR207-R209) [[3]](diffhunk://#diff-7cadcbfeb0e644a7a53c88412b316dbc0f222422c49f3e6723e1237c8f7a41adL214-R219) [[4]](diffhunk://#diff-7cadcbfeb0e644a7a53c88412b316dbc0f222422c49f3e6723e1237c8f7a41adR230-R246)

**Swipe Gesture and Asset Transition Handling:**
- Enhanced swipe gesture logic in `DetailView` to prevent concurrent transitions by introducing an `isTransitioning` state. Asset loading is now slightly delayed after a swipe to ensure proper cleanup of resources before loading the next asset.

**Album Fetching and Initialization:**
- Modified album fetching to run asynchronously on a background queue and set `albumsLoaded` to true only after albums have been fully processed and the first visible album selected. [[1]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737R149-R157) [[2]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737L172-R182) [[3]](diffhunk://#diff-0be1da4e4202ff59bc90f8538d27e733e257173c5b69414b4ca5cc06e9ff3737R363)

**Authorization Flow:**
- Updated the photo library authorization flow to explicitly handle the `.notDetermined` state, requesting access and updating status accordingly.

These changes collectively make the app more robust, especially around initial loading and media playback edge cases.