### PR TITLE
UI polish: restyle loading, access denied, and onboarding screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ DerivedData
 .idea/
 *.hmap
 xcuserdata/*
+.superpowers/

--- a/Simple Photo Viewer.xcodeproj/project.pbxproj
+++ b/Simple Photo Viewer.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -393,7 +393,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Simple Photo Viewer.xcodeproj/project.pbxproj
+++ b/Simple Photo Viewer.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		EFCDF8BE2B614CA90007C3BB /* AccessDeniedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCDF8BD2B614CA90007C3BB /* AccessDeniedView.swift */; };
 		EFCDF8C02B614CBC0007C3BB /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCDF8BF2B614CBC0007C3BB /* LoadingView.swift */; };
 		EFD5D21C2C52CD7A0028F269 /* LivePhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD5D21B2C52CD7A0028F269 /* LivePhotoView.swift */; };
+		EFD5D21E2C52CD7A0028F269 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD5D21D2C52CD7A0028F269 /* Color+Hex.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		EFCDF8BD2B614CA90007C3BB /* AccessDeniedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessDeniedView.swift; sourceTree = "<group>"; };
 		EFCDF8BF2B614CBC0007C3BB /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		EFD5D21B2C52CD7A0028F269 /* LivePhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoView.swift; sourceTree = "<group>"; };
+		EFD5D21D2C52CD7A0028F269 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				EFA87E852B62AA2C00F1D761 /* Simple-Photo-Viewer-Info.plist */,
 				EFCDF8BD2B614CA90007C3BB /* AccessDeniedView.swift */,
 				EFCDF8B52B60260C0007C3BB /* AlbumView.swift */,
+				EFD5D21D2C52CD7A0028F269 /* Color+Hex.swift */,
 				EF69CC642B6A80F4005A99AF /* AlbumRowView.swift */,
 				EF6CA37C2B5EBEE0005CBF53 /* ContentView.swift */,
 				EF6CA38D2B5EC229005CBF53 /* DetailView.swift */,
@@ -195,6 +198,7 @@
 				EF6CA38E2B5EC229005CBF53 /* DetailView.swift in Sources */,
 				EFCDF8B82B6026620007C3BB /* ViewModel.swift in Sources */,
 				EFD5D21C2C52CD7A0028F269 /* LivePhotoView.swift in Sources */,
+				EFD5D21E2C52CD7A0028F269 /* Color+Hex.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simple Photo Viewer/AccessDeniedView.swift
+++ b/Simple Photo Viewer/AccessDeniedView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct AccessDeniedView: View {
     var body: some View {

--- a/Simple Photo Viewer/AccessDeniedView.swift
+++ b/Simple Photo Viewer/AccessDeniedView.swift
@@ -1,18 +1,33 @@
-//
-//  AccessDeniedView.swift
-//  Simple Photo Viewer
-//
-//  Created by Michael Collins on 1/24/24.
-//
-
 import SwiftUI
 
 struct AccessDeniedView: View {
     var body: some View {
-        Text("Full Access to the photo library is required.\nIf you just granted it, please wait a moment for the application to load your data.\nOtherwise, please enable access in iOS Settings.")
-            .multilineTextAlignment(.center)
-            .lineSpacing(10)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding()
+        VStack(spacing: 16) {
+            Image(systemName: "photo.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+
+            Text("Photo Access Needed")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text("LE Viewer needs full access to your photo library to show photos.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button("Open Settings") {
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+
+            Text("Already granted? This screen updates automatically.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Simple Photo Viewer/AccessDeniedView.swift
+++ b/Simple Photo Viewer/AccessDeniedView.swift
@@ -18,7 +18,9 @@ struct AccessDeniedView: View {
                 .multilineTextAlignment(.center)
 
             Button("Open Settings") {
-                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)

--- a/Simple Photo Viewer/AlbumRowView.swift
+++ b/Simple Photo Viewer/AlbumRowView.swift
@@ -34,7 +34,7 @@ struct AlbumRowView: View {
             }
         }
         .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
-        .background(isSelected ? Color.blue.opacity(0.3) : Color.clear)
+        .background(isSelected ? Color.accentColor.opacity(0.3) : Color.clear)
         .cornerRadius(6)
         .overlay(
             Group {

--- a/Simple Photo Viewer/AlbumView.swift
+++ b/Simple Photo Viewer/AlbumView.swift
@@ -23,7 +23,7 @@ struct AlbumView: View {
                         .foregroundColor(.white)
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.blue)
+                        .background(Color.accentColor)
                         .cornerRadius(10)
                         .padding(.horizontal)
                 }

--- a/Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.259",
+          "green" : "0.549",
+          "red" : "1.000"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Simple Photo Viewer/Color+Hex.swift
+++ b/Simple Photo Viewer/Color+Hex.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255
+        let g = Double((int >> 8) & 0xFF) / 255
+        let b = Double(int & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/Simple Photo Viewer/Color+Hex.swift
+++ b/Simple Photo Viewer/Color+Hex.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 extension Color {

--- a/Simple Photo Viewer/InitialView.swift
+++ b/Simple Photo Viewer/InitialView.swift
@@ -3,19 +3,75 @@ import UIKit
 
 struct InitialView: View {
     @Binding var isFirstLaunch: Bool
+    @State private var currentPage = 0
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                header
-                aboutSection
-                guidedAccessCard
-                footerNote
-                ctaButton
+        TabView(selection: $currentPage) {
+            welcomePage.tag(0)
+            setupPage.tag(1)
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+        .indexViewStyle(.page(backgroundDisplayMode: .always))
+        .background(Color(UIColor.systemBackground).ignoresSafeArea())
+    }
+
+    // MARK: - Page 1: Welcome
+
+    private var welcomePage: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 32)
+                    header
+
+                    VStack(spacing: 0) {
+                        featureRow(
+                            icon: "checkmark.shield.fill",
+                            title: "Safe & Read-Only",
+                            description: "Nothing can be deleted, edited, or shared. Your photos and albums are completely protected."
+                        )
+                        featureRow(
+                            icon: "photo.on.rectangle",
+                            title: "Photos, Videos & Live Photos",
+                            description: "Browse your entire library in a clean, distraction-free layout — no cluttered menus or extra buttons."
+                        )
+                        featureRow(
+                            icon: "rectangle.stack",
+                            title: "Album Control",
+                            description: "Choose exactly which albums are visible. All settings are managed in the Settings app — never inside LE Viewer."
+                        )
+                        featureRow(
+                            icon: "lock.iphone",
+                            title: "Guided Access Ready",
+                            description: "Pair with iOS Guided Access to lock the device to this app, preventing access to anything else."
+                        )
+                    }
+                    .padding(.top, 8)
+
+                    Spacer(minLength: 32)
+                    nextButton
+                }
+                .frame(minHeight: geometry.size.height)
             }
         }
-        .background(Color(UIColor.systemBackground))
-        .ignoresSafeArea()
+    }
+
+    // MARK: - Page 2: Setup
+
+    private var setupPage: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 32)
+                    guidedAccessCard
+                    Spacer(minLength: 32)
+                    ctaButton
+                }
+                .frame(maxWidth: 600)
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: geometry.size.height)
+            }
+        }
     }
 
     // MARK: - Header
@@ -36,27 +92,37 @@ struct InitialView: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
-                .frame(maxWidth: 300)
+                .frame(maxWidth: 340)
         }
         .frame(maxWidth: .infinity)
-        .padding(.top, 32)
-        .padding(.bottom, 24)
-        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, 28)
+        .padding(.horizontal, 24)
     }
 
-    // MARK: - About
+    // MARK: - Feature Rows
 
-    private var aboutSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("ABOUT")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+    private func featureRow(icon: String, title: String, description: String) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.tint)
+                .frame(width: 36, alignment: .top)
+                .padding(.top, 2)
 
-            Text("All of your albums are visible by default. On the next screen you can hide individual albums. To change album visibility later, enable Show Album Settings in Settings → LE Viewer.")
-                .font(.body)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.body)
+                    .fontWeight(.semibold)
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
         }
-        .padding(.horizontal, 20)
-        .padding(.bottom, 8)
+        .padding(.horizontal, 32)
+        .padding(.vertical, 12)
     }
 
     // MARK: - Guided Access Card
@@ -86,17 +152,29 @@ struct InitialView: View {
     }
 
     private var cardHeader: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Set Up Guided Access")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(.tint)
-            Text("Locks the device to this app. Set up once in the Shortcuts app.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+        Button {
+            if let url = URL(string: "shortcuts://") {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Set Up Guided Access")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.tint)
+                    Text("Tap to open the Shortcuts app.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption)
+                    .foregroundStyle(.tint)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .padding(.horizontal, 16)
     }
 
@@ -132,16 +210,20 @@ struct InitialView: View {
         ]
     }
 
-    // MARK: - Footer + CTA
+    // MARK: - Buttons
 
-    private var footerNote: some View {
-        Text("Album visibility can be changed later in Settings → LE Viewer.")
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 20)
-            .padding(.top, 12)
+    private var nextButton: some View {
+        Button("Next") {
+            withAnimation {
+                currentPage = 1
+            }
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 72)
     }
 
     private var ctaButton: some View {
@@ -152,7 +234,7 @@ struct InitialView: View {
         .controlSize(.large)
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
-        .padding(.top, 16)
-        .padding(.bottom, 32)
+        .padding(.top, 12)
+        .padding(.bottom, 72)
     }
 }

--- a/Simple Photo Viewer/InitialView.swift
+++ b/Simple Photo Viewer/InitialView.swift
@@ -1,71 +1,157 @@
-//
-//  InitialView.swift
-//  Simple Photo Viewer
-//
-//  Created by Michael Collins on 5/1/24.
-//
-
 import SwiftUI
 
 struct InitialView: View {
     @Binding var isFirstLaunch: Bool
 
     var body: some View {
-        VStack {
-            Spacer()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                aboutSection
+                guidedAccessCard
+                footerNote
+                ctaButton
+            }
+        }
+        .background(Color(UIColor.systemBackground))
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 12) {
             Image("Logo")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 200, height: 200)
-            welcomeText
-            generalInfoText
-            instructionsText
-            closeButton
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .shadow(color: Color(hex: "#FF8C42").opacity(0.25), radius: 12, x: 0, y: 6)
+
+            Text("Welcome to LE Viewer")
+                .font(.title2)
+                .bold()
+
+            Text("A simplified photo viewer for children and people with special needs.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 300)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 32)
+        .padding(.bottom, 24)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - About
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("ABOUT")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("All of your albums are visible by default. On the next screen you can hide individual albums. To change album visibility later, enable Show Album Settings in Settings → LE Viewer.")
+                .font(.body)
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Guided Access Card
+
+    private var guidedAccessCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("RECOMMENDED SETUP")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 20)
+
+            VStack(spacing: 0) {
+                cardHeader
+                Divider()
+                ForEach(Array(steps.enumerated()), id: \.offset) { index, stepText in
+                    stepRow(number: index + 1, text: stepText)
+                    if index < steps.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+            .background(Color(UIColor.secondarySystemBackground))
+            .cornerRadius(12)
+            .padding(.horizontal, 16)
+        }
+        .padding(.bottom, 16)
+    }
+
+    private var cardHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Set Up Guided Access")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(Color(hex: "#FF6B35"))
+            Text("Locks the device to this app. Set up once in the Shortcuts app.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+    }
+
+    private func stepRow(number: Int, text: Text) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color(hex: "#FF8C42"))
+                    .frame(width: 24, height: 24)
+                Text("\(number)")
+                    .font(.caption)
+                    .bold()
+                    .foregroundColor(.white)
+            }
+            text.font(.callout)
             Spacer()
         }
-        .padding()
-        .background(Color.white)
-        .edgesIgnoringSafeArea(.all)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
     }
 
-    private var instructionsText: some View {
-        Text("""
-        1. Open Shortcuts.app
-        2. Tap Automation
-        3. Tap + Button
-        4. Tap "App"
-        5. Tap "Choose" and select LE Viewer
-        6. Leave "Is Opened" selected, select "Run Immediately" and tap Done
-        7. Tap "New Blank Automation"
-        8. Tap "Add Action"
-        9. Search for "Guided Access"
-        10. Select "Start Guided Access"
-        11. Tap Done
-        """)
-        .multilineTextAlignment(.leading)
-        .fixedSize(horizontal: false, vertical: true)
-        .padding(.bottom, 20)
+    // MARK: - Steps
+
+    private var steps: [Text] {
+        [
+            Text("Open ") + Text("Shortcuts").fontWeight(.semibold) + Text(", tap ") + Text("Automation").fontWeight(.semibold),
+            Text("Tap ") + Text("+").fontWeight(.semibold) + Text(", then tap ") + Text("App").fontWeight(.semibold),
+            Text("Tap ") + Text("Choose").fontWeight(.semibold) + Text(" and select ") + Text("LE Viewer").fontWeight(.semibold),
+            Text("Leave ") + Text("Is Opened").fontWeight(.semibold) + Text(" selected, tap ") + Text("Run Immediately").fontWeight(.semibold) + Text(", then ") + Text("Next").fontWeight(.semibold),
+            Text("Tap ") + Text("New Blank Automation").fontWeight(.semibold),
+            Text("Tap ") + Text("Add Action").fontWeight(.semibold) + Text(", search ") + Text("Guided Access").fontWeight(.semibold),
+            Text("Select ") + Text("Start Guided Access").fontWeight(.semibold) + Text(", tap ") + Text("Done").fontWeight(.semibold),
+        ]
     }
 
-    private var welcomeText: some View {
-        Text("Welcome to LE Viewer!")
-            .font(.largeTitle)
-            .fontWeight(.bold)
-            .padding(.bottom, 20)
+    // MARK: - Footer + CTA
+
+    private var footerNote: some View {
+        Text("Album visibility can be changed later in Settings → LE Viewer.")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
     }
 
-    private var generalInfoText: some View {
-        Text("""
-        This app is intended for children or users with special needs who benefit from a more "protected" media library experience. By default, all albums are displayed. On the next screen you will be able to hide individual albums. Following that process, the ability to hide or unhide can only be reinvoked by toggling the "Show album view settings" in Settings.app for this application. Additional settings, generally related to accessibility can also be found in Settings.app.\n
-        It is recommended you use this app with Guided Access:
-        """)
-        .padding(.bottom, 20)
-    }
-
-    private var closeButton: some View {
-        Button("Close") {
+    private var ctaButton: some View {
+        Button("Get Started") {
             isFirstLaunch = false
         }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 32)
     }
 }
-

--- a/Simple Photo Viewer/InitialView.swift
+++ b/Simple Photo Viewer/InitialView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct InitialView: View {
     @Binding var isFirstLaunch: Bool

--- a/Simple Photo Viewer/InitialView.swift
+++ b/Simple Photo Viewer/InitialView.swift
@@ -90,7 +90,7 @@ struct InitialView: View {
             Text("Set Up Guided Access")
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(Color(hex: "#FF6B35"))
+                .foregroundStyle(.tint)
             Text("Locks the device to this app. Set up once in the Shortcuts app.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -109,7 +109,7 @@ struct InitialView: View {
                 Text("\(number)")
                     .font(.caption)
                     .bold()
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
             text.font(.callout)
             Spacer()

--- a/Simple Photo Viewer/LoadingView.swift
+++ b/Simple Photo Viewer/LoadingView.swift
@@ -1,10 +1,3 @@
-//
-//  LoadingView.swift
-//  Simple Photo Viewer
-//
-//  Created by Michael Collins on 1/24/24.
-//
-
 import SwiftUI
 
 struct LoadingView: View {

--- a/Simple Photo Viewer/LoadingView.swift
+++ b/Simple Photo Viewer/LoadingView.swift
@@ -41,7 +41,7 @@ struct LoadingView: View {
     @ViewBuilder
     private var background: some View {
         if colorScheme == .dark {
-            Color(.systemBackground)
+            Color(UIColor.systemBackground)
                 .ignoresSafeArea()
         } else {
             LinearGradient(

--- a/Simple Photo Viewer/LoadingView.swift
+++ b/Simple Photo Viewer/LoadingView.swift
@@ -8,28 +8,48 @@
 import SwiftUI
 
 struct LoadingView: View {
-    var body: some View {
-        VStack {
-            Image("Logo")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 200, height: 200)
-            
-            Text("LE Viewer")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-                .foregroundColor(.primary)
-                .padding(.top, 20)
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var barOpacity: Double = 0.5
 
-            Text("Loading, please sit tight!")
-                .font(.headline)
-                .foregroundColor(.primary)
-            
-            ProgressView()
-                .scaleEffect(1.5, anchor: .center)
-                .progressViewStyle(CircularProgressViewStyle(tint: .primary))
-                .padding()
+    var body: some View {
+        ZStack {
+            background
+            VStack(spacing: 20) {
+                Image("Logo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .shadow(color: Color(hex: "#FF8C42").opacity(0.25), radius: 12, x: 0, y: 6)
+
+                Text("LE Viewer")
+                    .font(.title2)
+                    .bold()
+
+                Capsule()
+                    .fill(Color(hex: "#FF8C42"))
+                    .frame(width: 80, height: 4)
+                    .opacity(barOpacity)
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                            barOpacity = 1.0
+                        }
+                    }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        if colorScheme == .dark {
+            Color(.systemBackground)
+                .ignoresSafeArea()
+        } else {
+            LinearGradient(
+                colors: [Color(hex: "#FFF8F2"), Color(hex: "#FFE8D6")],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
         }
     }
 }
-

--- a/Simple Photo Viewer/Simple_Photo_ViewerApp.swift
+++ b/Simple Photo Viewer/Simple_Photo_ViewerApp.swift
@@ -14,6 +14,7 @@ struct Simple_Photo_ViewerApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .tint(Color(hex: "#FF8C42"))
         }
     }
 

--- a/docs/superpowers/plans/2026-03-23-ui-polish.md
+++ b/docs/superpowers/plans/2026-03-23-ui-polish.md
@@ -1,0 +1,523 @@
+# UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bare loading, access-denied, and first-launch screens with polished, native-feeling SwiftUI views that pass Apple App Review.
+
+**Architecture:** Pure view-layer changes only — no ViewModel, no data flow, no new dependencies. `Color+Hex.swift` provides a shared hex color initializer. Each of the three target views is rewritten in place. The accent color is set once in the asset catalog and propagates app-wide automatically.
+
+**Tech Stack:** SwiftUI, iOS 16+, SF Symbols, `UIApplication.openSettingsURLString`. No third-party libraries. No new tests (pure UI with no logic under test).
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|-------------|
+| Create | `Simple Photo Viewer/Color+Hex.swift` | `Color(hex:)` initializer used by all three views |
+| Modify | `Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json` | Set orange accent `#FF8C42` app-wide |
+| Rewrite | `Simple Photo Viewer/LoadingView.swift` | Warm gradient bg, styled logo, animated bar |
+| Rewrite | `Simple Photo Viewer/AccessDeniedView.swift` | Icon, headline, body, Open Settings button |
+| Rewrite | `Simple Photo Viewer/InitialView.swift` | Scroll layout, grouped list card, Get Started CTA |
+
+---
+
+## Task 1: Color+Hex helper and AccentColor
+
+**Files:**
+- Create: `Simple Photo Viewer/Color+Hex.swift`
+- Modify: `Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json`
+
+- [ ] **Step 1: Create `Color+Hex.swift`**
+
+  Create `Simple Photo Viewer/Color+Hex.swift` with this exact content:
+
+  ```swift
+  import SwiftUI
+
+  extension Color {
+      init(hex: String) {
+          let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+          var int: UInt64 = 0
+          Scanner(string: hex).scanHexInt64(&int)
+          let r = Double((int >> 16) & 0xFF) / 255
+          let g = Double((int >> 8) & 0xFF) / 255
+          let b = Double(int & 0xFF) / 255
+          self.init(red: r, green: g, blue: b)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Set the accent color**
+
+  Replace the contents of `Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json` with:
+
+  ```json
+  {
+    "colors" : [
+      {
+        "color" : {
+          "color-space" : "srgb",
+          "components" : {
+            "alpha" : "1.000",
+            "blue" : "0.259",
+            "green" : "0.549",
+            "red" : "1.000"
+          }
+        },
+        "idiom" : "universal"
+      }
+    ],
+    "info" : {
+      "author" : "xcode",
+      "version" : 1
+    }
+  }
+  ```
+
+  These are the sRGB components for `#FF8C42` (R: 255/255, G: 140/255, B: 66/255).
+
+- [ ] **Step 3: Add `Color+Hex.swift` to the Xcode project**
+
+  Open `Simple Photo Viewer.xcodeproj` in Xcode. In the Project Navigator, right-click the `Simple Photo Viewer` folder and choose **Add Files to "Simple Photo Viewer"**. Select `Color+Hex.swift`. Make sure **Target Membership** is checked for `Simple Photo Viewer`.
+
+  > Note: If working purely from the command line without opening Xcode, you must also add the file reference to `project.pbxproj`. The easiest path is to open Xcode for this step.
+
+- [ ] **Step 4: Build to confirm no errors**
+
+  In Xcode press **Cmd+B**, or run:
+  ```bash
+  xcodebuild -project "Simple Photo Viewer.xcodeproj" \
+    -scheme "Simple Photo Viewer" \
+    -destination 'platform=iOS Simulator,name=iPad Pro 11-inch (M4)' \
+    build 2>&1 | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED"
+  ```
+  Expected: `BUILD SUCCEEDED` with no errors.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git checkout -b dev/michaelcollins/ui-polish
+  git add "Simple Photo Viewer/Color+Hex.swift" \
+          "Simple Photo Viewer/Assets.xcassets/AccentColor.colorset/Contents.json" \
+          "Simple Photo Viewer.xcodeproj/project.pbxproj"
+  git commit -m "Add Color+Hex helper and set orange accent color"
+  ```
+
+---
+
+## Task 2: LoadingView
+
+**Files:**
+- Rewrite: `Simple Photo Viewer/LoadingView.swift`
+
+- [ ] **Step 1: Rewrite `LoadingView.swift`**
+
+  Replace the entire file contents:
+
+  ```swift
+  import SwiftUI
+
+  struct LoadingView: View {
+      @Environment(\.colorScheme) private var colorScheme
+      @State private var barOpacity: Double = 0.5
+
+      var body: some View {
+          ZStack {
+              background
+              VStack(spacing: 20) {
+                  Image("Logo")
+                      .resizable()
+                      .scaledToFit()
+                      .frame(width: 80, height: 80)
+                      .shadow(color: Color(hex: "#FF8C42").opacity(0.25), radius: 12, x: 0, y: 6)
+
+                  Text("LE Viewer")
+                      .font(.title2)
+                      .bold()
+
+                  Capsule()
+                      .fill(Color(hex: "#FF8C42"))
+                      .frame(width: 80, height: 4)
+                      .opacity(barOpacity)
+                      .onAppear {
+                          withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                              barOpacity = 1.0
+                          }
+                      }
+              }
+          }
+      }
+
+      @ViewBuilder
+      private var background: some View {
+          if colorScheme == .dark {
+              Color(.systemBackground)
+                  .ignoresSafeArea()
+          } else {
+              LinearGradient(
+                  colors: [Color(hex: "#FFF8F2"), Color(hex: "#FFE8D6")],
+                  startPoint: .top,
+                  endPoint: .bottom
+              )
+              .ignoresSafeArea()
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify in Xcode Preview**
+
+  Open `LoadingView.swift` in Xcode and check the canvas preview. You should see:
+  - Warm peach gradient background (light mode)
+  - 80×80 logo with a subtle orange drop shadow
+  - "LE Viewer" in bold title font
+  - A small orange capsule bar (will pulse in the simulator)
+  - No "Loading, please sit tight!" text
+
+  Also check the preview in dark mode using the Variants button in the preview canvas. Background should be solid (no gradient).
+
+- [ ] **Step 3: Build**
+
+  **Cmd+B** in Xcode. Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "Simple Photo Viewer/LoadingView.swift"
+  git commit -m "Restyle LoadingView with warm gradient and animated bar"
+  ```
+
+---
+
+## Task 3: AccessDeniedView
+
+**Files:**
+- Rewrite: `Simple Photo Viewer/AccessDeniedView.swift`
+
+- [ ] **Step 1: Rewrite `AccessDeniedView.swift`**
+
+  Replace the entire file contents:
+
+  ```swift
+  import SwiftUI
+
+  struct AccessDeniedView: View {
+      var body: some View {
+          VStack(spacing: 16) {
+              Image(systemName: "photo.fill")
+                  .font(.system(size: 56))
+                  .foregroundStyle(.tint)
+
+              Text("Photo Access Needed")
+                  .font(.title3)
+                  .fontWeight(.semibold)
+
+              Text("LE Viewer needs full access to your photo library to show photos.")
+                  .font(.body)
+                  .foregroundStyle(.secondary)
+                  .multilineTextAlignment(.center)
+
+              Button("Open Settings") {
+                  UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+              }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.large)
+
+              Text("Already granted? This screen updates automatically.")
+                  .font(.footnote)
+                  .foregroundStyle(.secondary)
+                  .multilineTextAlignment(.center)
+          }
+          .padding(40)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify in Xcode Preview**
+
+  Check the preview canvas. You should see:
+  - A large photo icon in the accent color (orange)
+  - "Photo Access Needed" headline
+  - Body text
+  - A filled orange "Open Settings" button
+  - Footnote below it
+
+  Check dark mode variant — everything should adapt correctly via system colors.
+
+- [ ] **Step 3: Build**
+
+  **Cmd+B**. Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "Simple Photo Viewer/AccessDeniedView.swift"
+  git commit -m "Restyle AccessDeniedView with icon and Open Settings button"
+  ```
+
+---
+
+## Task 4: InitialView
+
+**Files:**
+- Rewrite: `Simple Photo Viewer/InitialView.swift`
+
+This is the most complex view. The Guided Access steps use `Text` concatenation to bold specific UI element names inline without a custom component.
+
+- [ ] **Step 1: Rewrite `InitialView.swift`**
+
+  Replace the entire file contents:
+
+  ```swift
+  import SwiftUI
+
+  struct InitialView: View {
+      @Binding var isFirstLaunch: Bool
+
+      var body: some View {
+          ScrollView {
+              VStack(alignment: .leading, spacing: 0) {
+                  header
+                  aboutSection
+                  guidedAccessCard
+                  footerNote
+                  ctaButton
+              }
+          }
+          .background(Color(.systemBackground))
+          .ignoresSafeArea()
+      }
+
+      // MARK: - Header
+
+      private var header: some View {
+          VStack(spacing: 12) {
+              Image("Logo")
+                  .resizable()
+                  .scaledToFit()
+                  .frame(width: 80, height: 80)
+                  .shadow(color: Color(hex: "#FF8C42").opacity(0.25), radius: 12, x: 0, y: 6)
+
+              Text("Welcome to LE Viewer")
+                  .font(.title2)
+                  .bold()
+
+              Text("A simplified photo viewer for children and people with special needs.")
+                  .font(.subheadline)
+                  .foregroundStyle(.secondary)
+                  .multilineTextAlignment(.center)
+                  .frame(maxWidth: 300)
+          }
+          .frame(maxWidth: .infinity)
+          .padding(.top, 32)
+          .padding(.bottom, 24)
+          .padding(.horizontal, 20)
+      }
+
+      // MARK: - About
+
+      private var aboutSection: some View {
+          VStack(alignment: .leading, spacing: 6) {
+              Text("ABOUT")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+
+              Text("All of your albums are visible by default. On the next screen you can hide individual albums. To change album visibility later, enable Show Album Settings in Settings → LE Viewer.")
+                  .font(.body)
+          }
+          .padding(.horizontal, 20)
+          .padding(.bottom, 8)
+      }
+
+      // MARK: - Guided Access Card
+
+      private var guidedAccessCard: some View {
+          VStack(alignment: .leading, spacing: 6) {
+              Text("RECOMMENDED SETUP")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+                  .padding(.horizontal, 20)
+
+              VStack(spacing: 0) {
+                  cardHeader
+                  Divider()
+                  ForEach(Array(steps.enumerated()), id: \.offset) { index, stepText in
+                      stepRow(number: index + 1, text: stepText)
+                      if index < steps.count - 1 {
+                          Divider()
+                      }
+                  }
+              }
+              .background(Color(.secondarySystemBackground))
+              .cornerRadius(12)
+              .padding(.horizontal, 16)
+          }
+          .padding(.bottom, 16)
+      }
+
+      private var cardHeader: some View {
+          VStack(alignment: .leading, spacing: 4) {
+              Text("Set Up Guided Access")
+                  .font(.subheadline)
+                  .fontWeight(.semibold)
+                  .foregroundColor(Color(hex: "#FF6B35"))
+              Text("Locks the device to this app. Set up once in the Shortcuts app.")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.vertical, 12)
+          .padding(.horizontal, 16)
+      }
+
+      private func stepRow(number: Int, text: Text) -> some View {
+          HStack(spacing: 12) {
+              ZStack {
+                  Circle()
+                      .fill(Color(hex: "#FF8C42"))
+                      .frame(width: 24, height: 24)
+                  Text("\(number)")
+                      .font(.caption)
+                      .bold()
+                      .foregroundColor(.white)
+              }
+              text.font(.callout)
+              Spacer()
+          }
+          .padding(.vertical, 10)
+          .padding(.horizontal, 16)
+      }
+
+      // MARK: - Steps
+
+      private var steps: [Text] {
+          [
+              Text("Open ") + Text("Shortcuts").fontWeight(.semibold) + Text(", tap ") + Text("Automation").fontWeight(.semibold),
+              Text("Tap ") + Text("+").fontWeight(.semibold) + Text(", then tap ") + Text("App").fontWeight(.semibold),
+              Text("Tap ") + Text("Choose").fontWeight(.semibold) + Text(" and select ") + Text("LE Viewer").fontWeight(.semibold),
+              Text("Leave ") + Text("Is Opened").fontWeight(.semibold) + Text(" selected, tap ") + Text("Run Immediately").fontWeight(.semibold) + Text(", then ") + Text("Next").fontWeight(.semibold),
+              Text("Tap ") + Text("New Blank Automation").fontWeight(.semibold),
+              Text("Tap ") + Text("Add Action").fontWeight(.semibold) + Text(", search ") + Text("Guided Access").fontWeight(.semibold),
+              Text("Select ") + Text("Start Guided Access").fontWeight(.semibold) + Text(", tap ") + Text("Done").fontWeight(.semibold),
+          ]
+      }
+
+      // MARK: - Footer + CTA
+
+      private var footerNote: some View {
+          Text("Album visibility can be changed later in Settings → LE Viewer.")
+              .font(.footnote)
+              .foregroundStyle(.secondary)
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: .infinity)
+              .padding(.horizontal, 20)
+              .padding(.top, 12)
+      }
+
+      private var ctaButton: some View {
+          Button("Get Started") {
+              isFirstLaunch = false
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.large)
+          .frame(maxWidth: .infinity)
+          .padding(.horizontal, 16)
+          .padding(.top, 16)
+          .padding(.bottom, 32)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify in Xcode Preview**
+
+  Check the preview canvas. You should see:
+  - Logo + "Welcome to LE Viewer" + subtitle, centered at top
+  - "ABOUT" section label followed by the about paragraph
+  - "RECOMMENDED SETUP" section label
+  - Rounded card with "Set Up Guided Access" orange header and 7 numbered rows
+  - Each step has a filled orange circle with a white number; key terms are bold
+  - Dividers between rows (not after the last)
+  - Footer footnote
+  - Full-width orange "Get Started" button at the bottom
+
+  Check dark mode variant — the card background should shift to `secondarySystemBackground` (dark gray), text should be white.
+
+  If the preview shows the first-launch screen (instead of the main UI), you can force it by adding a preview that passes `.constant(true)` for `isFirstLaunch`:
+  ```swift
+  #Preview {
+      InitialView(isFirstLaunch: .constant(true))
+  }
+  ```
+
+- [ ] **Step 3: Build**
+
+  **Cmd+B**. Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Smoke test on simulator**
+
+  Run on an iPad simulator. To trigger the first-launch screen, delete the app data (or reset `isFirstLaunch` in UserDefaults via the simulator). The screen should appear on launch, scroll correctly, and tapping "Get Started" should dismiss it and show the main photo grid.
+
+  To reset the first-launch flag without deleting the app, run this from Terminal (replace the UDID with your simulator's):
+  ```bash
+  # Find your booted simulator's UDID
+  xcrun simctl list devices booted
+
+  # Reset the isFirstLaunch UserDefaults key
+  xcrun simctl spawn booted defaults delete "$(xcrun simctl getenv booted SIMULATOR_APP_BUNDLE_IDENTIFIER 2>/dev/null || echo 'com.michaelcollins.LEViewer')" isFirstLaunch
+  ```
+  Or simply delete and reinstall the app from the simulator home screen.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add "Simple Photo Viewer/InitialView.swift"
+  git commit -m "Restyle InitialView with native grouped list and Get Started CTA"
+  ```
+
+---
+
+## Task 5: Final check and PR
+
+- [ ] **Step 1: Run on simulator end-to-end**
+
+  Install fresh on an iPad simulator (no existing app data). Walk through:
+  1. App launches → `LoadingView` appears with warm gradient and pulsing bar
+  2. Loader dismisses → `InitialView` appears with full onboarding layout
+  3. Tap "Get Started" → main photo grid appears (or `AccessDeniedView` if permissions not granted)
+  4. If `AccessDeniedView` appears: icon, headline, "Open Settings" button, and footnote are visible
+
+- [ ] **Step 2: Check dark mode**
+
+  In the simulator menu bar: **Features → Toggle Appearance**. Verify:
+  - `LoadingView`: solid dark background, no gradient
+  - `AccessDeniedView`: system dark background, all text readable
+  - `InitialView`: dark system background, card uses `secondarySystemBackground` (dark gray), text is white
+
+- [ ] **Step 3: Create PR**
+
+  Use the `create-pr` skill (or `gh pr create`) to open a PR from `dev/michaelcollins/ui-polish` to `main`:
+
+  ```bash
+  gh pr create \
+    --title "UI polish: loading, access denied, and onboarding screens" \
+    --body "$(cat <<'EOF'
+  ## Summary
+  - Replaced bare loading screen with warm gradient background and animated progress bar
+  - Replaced plain-text access denied screen with icon, headline, and Open Settings deep-link button
+  - Replaced wall-of-text onboarding with scrollable layout, native grouped list for Guided Access steps, and Get Started CTA
+  - Fixed hardcoded `Color.white` in InitialView (dark mode was broken)
+  - Set app-wide accent color to orange (#FF8C42) via AccentColor.colorset
+  - Corrected Guided Access steps for iOS 18 (11 steps → 7, fixed "tap Done" → "tap Next")
+
+  ## Test plan
+  - [ ] Fresh install on iPad simulator — LoadingView shows warm gradient and pulsing bar
+  - [ ] InitialView shows full scrollable layout with numbered Guided Access steps
+  - [ ] Tapping Get Started dismisses onboarding and shows main grid
+  - [ ] AccessDeniedView shows icon, headline, and Open Settings button
+  - [ ] Open Settings button deep-links to Settings → LE Viewer
+  - [ ] All three screens look correct in dark mode
+  EOF
+  )"
+  ```

--- a/docs/superpowers/specs/2026-03-23-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-03-23-ui-polish-design.md
@@ -1,0 +1,183 @@
+# UI Polish Design Spec
+**Date:** 2026-03-23
+**Branch:** dev/michaelcollins/ui-polish (to be created from main)
+**Goal:** Improve the visual quality of loading, onboarding, and error screens to pass Apple App Review.
+
+---
+
+## Context
+
+Apple Review feedback flagged the launch page and first-time instructions as visually poor. The app's core functionality (photo browsing, album management, Guided Access support) is intentionally minimal and is not in scope. Only the UI-facing screens that Apple reviewers see first are being improved.
+
+- **Deployment target:** iOS 16.0
+- **Device family:** iPad only (TARGETED_DEVICE_FAMILY = 2). iPhone support is a future goal; designs should use adaptive layouts and avoid iPad-specific hard-coded sizes.
+
+Primary users of the improved screens:
+- **Parent/caretaker** — sees the first-launch onboarding screen once during setup
+- **Child/end user** — sees the loading screen on each launch; may see the access denied screen
+
+---
+
+## Design Direction
+
+**Warm & Friendly** — orange/peach accent color, soft warm backgrounds in light mode, native iOS dark backgrounds in dark mode. Approachable without being childish. Feels like a polished native app.
+
+**Accent color:** `#FF8C42` — set as the universal color in `AccentColor.colorset`. This automatically applies to `Button` fills, `Toggle` tints, and `ProgressView` when no explicit color is set.
+
+**Backgrounds:** Always use adaptive SwiftUI colors (`.systemBackground`, `.secondarySystemBackground`). Never hardcode `Color.white` or hex backgrounds in view code.
+
+**New file required:** `Color+Hex.swift` — a `Color` extension providing `init(hex: String)`. This is needed for the gradient background colors. Example implementation:
+
+```swift
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255
+        let g = Double((int >> 8) & 0xFF) / 255
+        let b = Double(int & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}
+```
+
+---
+
+## Screens
+
+### 1. LoadingView
+
+**Current issues:** Informal copy ("please sit tight!"), default `ProgressView` spinner, no visual polish.
+
+**Proposed:**
+
+**Background:** Warm gradient that adapts to dark mode using `@Environment(\.colorScheme)`:
+- Light: `LinearGradient` from `Color(hex: "#FFF8F2")` to `Color(hex: "#FFE8D6")`, `startPoint: .top, endPoint: .bottom`
+- Dark: `.systemBackground` (solid, no gradient)
+
+**Layout (centered VStack, spacing: 20):**
+1. `Image("Logo")` — 80×80, `.scaledToFit()`, with drop shadow: `.shadow(color: Color(hex: "#FF8C42").opacity(0.25), radius: 12, x: 0, y: 6)`
+2. `Text("LE Viewer")` — `.title2`, `.bold`, `.primary`
+3. Animated loading bar (see below)
+
+Remove the "Loading, please sit tight!" text entirely.
+
+**Animated loading bar:** A `Capsule` filled with `Color(hex: "#FF8C42")`, height 4pt, width 80pt, with a repeating opacity animation:
+- Opacity oscillates from 0.5 to 1.0
+- Duration: 1.0 second
+- `autoreverse: true`, `repeatForever(autoreverses: true)`
+- Use `.onAppear` to start the animation with `withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true))`
+
+---
+
+### 2. AccessDeniedView
+
+**Current issues:** Plain `Text()` only, no icon, no action button, no visual hierarchy.
+
+**Proposed (centered VStack, spacing: 16, padding: 40):**
+
+1. `Image(systemName: "photo.fill")` — font size 56pt, foreground `.tint` (picks up accent color). Note: `photo.fill` is available since iOS 13; do not use `photo.on.rectangle.angled` which requires iOS 17.
+2. `Text("Photo Access Needed")` — `.title3`, `.semibold`
+3. `Text("LE Viewer needs full access to your photo library to show photos.")` — `.body`, `.secondary`, `.multilineTextAlignment(.center)`
+4. `Button("Open Settings")` — calls `UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)`. The URL is guaranteed non-nil by the iOS SDK; no error handling needed. Style as `.buttonStyle(.borderedProminent)` with `.controlSize(.large)`.
+5. `Text("Already granted? This screen updates automatically.")` — `.footnote`, `.secondary`, `.multilineTextAlignment(.center)`
+
+Note: The existing timer in `ContentView.setupAccessCheckTimer()` already polls for access changes every 2 seconds and dismisses this view automatically when access is granted. No additional logic needed in `AccessDeniedView`.
+
+---
+
+### 3. InitialView (First-Launch Onboarding)
+
+**Current issues:** Hardcoded `Color.white` (dark mode broken), dense wall of text, plain "Close" button, deprecated `edgesIgnoringSafeArea(.all)`, no visual hierarchy.
+
+**Proposed layout:**
+
+Wrap the entire content in a `ScrollView` containing a `VStack(alignment: .leading, spacing: 0)`. This ensures it doesn't clip on smaller iPads or future iPhone support.
+
+Replace `.background(Color.white).edgesIgnoringSafeArea(.all)` with `.background(Color(.systemBackground)).ignoresSafeArea()`.
+
+User may dismiss ("Get Started") at any point without having read all the steps — no read-gating needed. The button is always active.
+
+**Section 1 — Header (centered, padding: top 32, bottom 24):**
+
+```
+VStack(spacing: 12) {
+    Image("Logo") — 80×80, .scaledToFit(), same drop shadow as LoadingView
+    Text("Welcome to LE Viewer") — .title2, .bold
+    Text("A simplified photo viewer for children and people with special needs.")
+        — .subheadline, .secondary, .multilineTextAlignment(.center), max width 300pt
+}
+.frame(maxWidth: .infinity)
+.padding(.top, 32)
+.padding(.bottom, 24)
+.padding(.horizontal, 20)
+```
+
+**Section 2 — About (padding: horizontal 20, bottom 8):**
+
+Section label: `Text("ABOUT")` — `.caption`, `.secondary`, uppercase (match iOS Settings section header style), padding bottom 6.
+
+Body copy:
+> "All of your albums are visible by default. On the next screen you can hide individual albums. To change album visibility later, enable Show Album Settings in Settings → LE Viewer."
+
+Style: `.body`, no card background, standard `.primary` text. Padding: `.horizontal(20)`.
+
+**Section 3 — Guided Access card (padding: horizontal 16, bottom 16):**
+
+Section label: `Text("RECOMMENDED SETUP")` — `.caption`, `.secondary`, uppercase, padding horizontal 20, bottom 6.
+
+Card: `VStack(spacing: 0)` with `.background(Color(.secondarySystemBackground))`, `.cornerRadius(12)`, `.padding(.horizontal, 16)`.
+
+Inside the card:
+
+- **Card header row** (`.padding(.vertical, 12).padding(.horizontal, 16)`, `Divider()` below):
+  - `Text("Set Up Guided Access")` — `.subheadline`, `.semibold`, foreground `Color(hex: "#FF6B35")`
+  - `Text("Locks the device to this app. Set up once in the Shortcuts app.")` — `.caption`, `.secondary`
+
+- **Step rows** — 7 rows, each:
+  - `HStack(spacing: 12)` with `Divider()` between each row (not after the last)
+  - Number badge: `ZStack { Circle().fill(Color(hex: "#FF8C42")).frame(width: 24, height: 24); Text("\(stepNumber)").font(.caption).bold().foregroundColor(.white) }` where `stepNumber` is the `Int` loop index + 1
+  - Step text: `.callout`, key UI element names wrapped in `Text` with `.fontWeight(.semibold)` (use attributed strings or concatenated `Text` views)
+
+  Steps (corrected for iOS 18):
+  1. Open **Shortcuts**, tap **Automation**
+  2. Tap **+**, then tap **App**
+  3. Tap **Choose** and select **LE Viewer**
+  4. Leave **Is Opened** selected, tap **Run Immediately**, then **Next**
+  5. Tap **New Blank Automation**
+  6. Tap **Add Action**, search **Guided Access**
+  7. Select **Start Guided Access**, tap **Done**
+
+  Use `Divider()` (not a manual `Rectangle`) between rows for native behavior.
+
+**Section 4 — Footer note:**
+
+`Text("Album visibility can be changed later in Settings → LE Viewer.")`
+— `.footnote`, `.secondary`, `.multilineTextAlignment(.center)`, `.padding(.horizontal, 20)`, `.padding(.top, 12)`
+
+**Section 5 — CTA Button:**
+
+`Button("Get Started") { isFirstLaunch = false }`
+— `.buttonStyle(.borderedProminent)`, `.controlSize(.large)`, `.frame(maxWidth: .infinity)`, `.padding(.horizontal, 16)`, `.padding(.top, 16)`, `.padding(.bottom, 32)`
+
+---
+
+## New File
+
+**`Color+Hex.swift`** — add to the `Simple Photo Viewer` target. Contains only the `Color(hex:)` initializer defined above. No other changes.
+
+---
+
+## Other Changes
+
+- **`AccentColor.colorset`** — set universal color to `#FF8C42` (RGB: 255/140/66)
+- **`.gitignore`** — add `.superpowers/` entry
+
+---
+
+## Out of Scope
+
+- `MainUI`, `ThumbnailListView`, `DetailView`, `AlbumView` — no changes to core browsing experience
+- App icon
+- LaunchScreen storyboard — app uses in-app `LoadingView`; keep as-is


### PR DESCRIPTION
## Summary

- **LoadingView**: replaced default `ProgressView` spinner and informal copy with warm gradient background (light/dark adaptive), app logo, title, and animated orange loading bar
- **AccessDeniedView**: replaced plain text with icon, clear headline, body copy, an "Open Settings" button, and a footnote that the screen updates automatically when access is granted
- **InitialView**: replaced hardcoded `Color.white` background (broken in dark mode), dense text wall, and "Close" button with a scrollable layout — header with logo, an About section, a native grouped-list Guided Access card with 7 iOS 18-accurate steps, footer note, and a prominent "Get Started" CTA
- **Color+Hex.swift**: new helper for hex color literals used in the gradient and accent elements
- **AccentColor.colorset**: set to `#FF8C42` so buttons, toggles, and progress views pick it up automatically
- **.gitignore**: added `.superpowers/` entry

## Test plan

- [ ] Build succeeds on iPad simulator (no errors or warnings)
- [ ] LoadingView: warm gradient visible in light mode; solid `.systemBackground` in dark mode; orange bar pulses continuously
- [ ] AccessDeniedView: icon, headline, body, "Open Settings" button, and footnote all visible; button opens Settings
- [ ] InitialView: scrollable on smaller iPads; all 7 Guided Access steps correct; "Get Started" dismisses the view; dark mode looks correct (no white background)
- [ ] Accent color (`#FF8C42`) appears on buttons and interactive elements throughout the app