### PR TITLE
Bump to 1.4 (1) and clarify photo library purpose string

### DIFF
--- a/Simple Photo Viewer.xcodeproj/project.pbxproj
+++ b/Simple Photo Viewer.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Simple Photo Viewer/Simple_Photo_Viewer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Simple Photo Viewer/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -335,7 +335,7 @@
 				INFOPLIST_FILE = "Simple-Photo-Viewer-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "LE Viewer";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app requires access to the photo library.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "LE Viewer needs access to your photo library so it can display your photos and videos in a simplified, full-screen viewer. For example, a child or a person with accessibility needs can safely browse family pictures on their own.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -350,7 +350,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -369,7 +369,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Simple Photo Viewer/Simple_Photo_Viewer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Simple Photo Viewer/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -378,7 +378,7 @@
 				INFOPLIST_FILE = "Simple-Photo-Viewer-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "LE Viewer";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app requires access to the photo library.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "LE Viewer needs access to your photo library so it can display your photos and videos in a simplified, full-screen viewer. For example, a child or a person with accessibility needs can safely browse family pictures on their own.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -393,7 +393,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.LE-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
## Summary
- Set `MARKETING_VERSION` to **1.4** and `CURRENT_PROJECT_VERSION` to **1** for the next App Store build. Relative to `main` this is 1.2 -> 1.4 and build 2 -> 1; the interim 1.3 build was submitted to the App Store but its version bump was never committed to git. The build reset to 1 is valid because 1.4 is a new marketing version (App Store Connect only enforces build uniqueness within a marketing version).
- Replace the vague `NSPhotoLibraryUsageDescription` ("This app requires access to the photo library.") with a specific description and example, per App Review **Guideline 5.1.1(ii)**. Applied to both build configurations.

Addresses #84. Part of the v1.3 rejection resubmission plan (#90).

No calendar string was added: the app has no calendar/EventKit usage, so the reviewer's "calendar" reference appears to be boilerplate.

## Test plan
- [ ] Open in Xcode; target General shows Version 1.4, Build 1
- [ ] Build succeeds
- [ ] On first launch, the photo access prompt shows the new, specific purpose string